### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Build Backtrack's Docker image
       run: docker build . --file Dockerfile --tag backtrack-server:latest
     - name: Publish Backtrack Server to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: registry.digitalocean.com/parrotmac/backtrack-server:latest
         username: ${{ secrets.DO_REGISTRY_TOKEN }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore